### PR TITLE
fix:bokeh no 2.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib>=3.2.2
 seaborn>=0.11.0
 scikit_learn>=0.24.1
 plotly>=5.0.0
-bokeh>=2.2.2
+bokeh>=2.2.2,<=2.4.1
 altair>=4.1.0
 pydeck>=0.6.2
 pandas_profiling


### PR DESCRIPTION
Streamlit currently only supports version 2.4.1. This fix allows `pip install -r requirements.txt` to not install 2.4.2

2022-03-20 13:16:32.138 Traceback (most recent call last):
  File "/Users/gar/gb_updates/venv/lib/python3.8/site-packages/streamlit/script_runner.py", line 430, in _run_script
    exec(code, module.__dict__)
  File "/Users/gar/gb_updates/trees_app/all_code.py", line 118, in <module>
    st.bokeh_chart(scatterplot)
  File "/Users/gar/gb_updates/venv/lib/python3.8/site-packages/streamlit/elements/bokeh_chart.py", line 73, in bokeh_chart
    raise StreamlitAPIException(
streamlit.errors.StreamlitAPIException: Streamlit only supports Bokeh version 2.4.1, but you have version 2.4.2 installed. Please run `pip install --force-reinstall --no-deps bokeh==2.4.1` to install the correct version.