### PR TITLE
fix:pandas no 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 streamlit>=0.81.0
 numpy>=1.18.5
 streamlit_lottie
-pandas>=1.0.5
+pandas>=1.0.5,<=1.3.5
 matplotlib>=3.2.2
 seaborn>=0.11.0
 scikit_learn>=0.24.1


### PR DESCRIPTION
Seems like open pandas profiling bug after pandas made a change [see issue](https://github.com/ydataai/pandas-profiling/issues/911)


  File "/Users/gar/gb_updates/venv/lib/python3.8/site-packages/pandas_profiling/model/pandas/utils_pandas.py", line 13, in weighted_median
    w_median = (data[weights == np.max(weights)])[0]
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices